### PR TITLE
Fix positioning of credits in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <a href="https://valence-native.js.org">
     <img alt="valence native" src="https://cdn.discordapp.com/attachments/801506779979841580/806295470447132712/valence-native.svg">
   </a>
+  <br/>
   Logo by <a href="https://github.com/aramodi">@aramodi</a>
 </p>
 


### PR DESCRIPTION
'ight so basically the credits should be under the icon in the README, but instead it currently sits in this weird position
![image](https://user-images.githubusercontent.com/67464646/123283253-8523bb00-d50b-11eb-9b34-a66a6f988fc6.png)
This PR just simply fixes this by moving it here
![image](https://user-images.githubusercontent.com/67464646/123283371-a1bff300-d50b-11eb-85c6-58cc9c49e6d0.png)

